### PR TITLE
Bake GOVC into the base container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:latest
 
 RUN  apt-get update && apt-get install -y git apt-utils dialog dosfstools mtools xmlstarlet curl jq
+RUN curl -L https://github.com/vmware/govmomi/releases/download/v0.21.0/govc_linux_amd64.gz \
+    | gunzip > /usr/local/bin/govc \
+    && chmod +x /usr/local/bin/govc
 RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core \
     && ./install.sh /usr/local

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ That said, the autounattend xml is complex and confusing. So attempts are made t
 
   1. A current Windows image. Testing was done with Windows Server 2019 but you could also use Server 1709 or Server 1803. Windows ISO images are not distributable. You will need to manually add it to the vSphere datastore. Note within the store, the pipeline is expecting the ISO to be within a datastore folder named `Win-Stemcell-ISO`. For testing you can download the [trial Windows Server 2019 ISO](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019).
 
-  1. Govc executable, see the [docs](https://github.com/vmware/govmomi) for more detail. The pipeleline is set to download the latest stable 0.21 release.
+  1. Govc executable, see the [docs](https://github.com/vmware/govmomi) for more detail. The build image uses the latest stable 0.21 release.
 
   1. The Local Group Policy Object(LGPO) Utility. See the [docs](https://blogs.technet.microsoft.com/secguide/2016/01/21/lgpo-exe-local-group-policy-object-utility-v1-0/) for more detail. The pipeline is set to download the latest release.
 
@@ -57,7 +57,6 @@ That said, the autounattend xml is complex and confusing. So attempts are made t
 
 The pipeline assumes your Concourse workers have access to the internet. If thats not the case, you can download the needed assets to a local S3 compatible bucket can adjust the pipeline to retrieve from there. You'll need to made the following available:
 
-- Govc
 - LGPO
 - Stembuild
 - A clone of this repo

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Additionally you'll need to add the docker images to a local repository and adju
 | vcenter-username | User to interact with vcenter server. Needs the permission to create/config/remove VMs. | Yes | (string) |
 | vcenter-password | Password for vcenter user. | Yes | (string) |
 | vcenter-datacenter | Vsphere datacenter name, for placing VMs and data. Do not include a slash(/). | Yes | (alphanumeric, underscore, dash) |
-| vcenter-ca-certs | To connect with vcenter over a secure connection, you'll need to provide the certificate. Follow [this vmware doc](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.vcli.getstart.doc%2FGUID-9AF8E0A7-1A64-4839-AB97-2F18D8ECB9FE.html) to retrieve the Base64 string. Stembuild requires secure connections, which makes this variable required. | Yes | (string) |
+| vcenter-ca-certs | To connect with vcenter over a secure connection, you'll need to provide the certificate. Follow [this vmware doc](https://kb.vmware.com/s/article/2108294) to retrieve the Base64 string. Stembuild requires secure connections, which makes this variable required. | Yes | (string) |
 | base-vm-name | The name of the initial Windows VM created, used as a clone for stembuild. | Yes | **Win-Stemcell-Base** |
 | vm-folder | The vsphere datacenter VM folder to hold base and clone VMs. | Yes | Stemcell |
 | vm-datastore | The vsphere datastore to hold VM disks. | Yes | (alphanumeric, underscore, dash) |

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -151,6 +151,7 @@ jobs:
           pipeline-resources: pipeline-resources
         params:
           <<: *vcenter-params
+          <<: *vm-params
           <<: *os-params
 
   - name: clone-base

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -40,13 +40,6 @@ resources:
     tag_filter: ((os-version)).(.*)
   check_every: 1h  
 
-- name: govc
-  type: github-release
-  source:
-    owner: vmware
-    repository: govmomi
-    tag_filter: 0.21.(.*)
-  check_every: 1h
 - name: lgpo
   type: file-url
   source:
@@ -113,16 +106,11 @@ jobs:
     plan:
       - get: windows-stemcell-concourse-image
       - get: pipeline-resources
-      - get: govc
-        params:
-          globs:
-            - govc_linux_amd64.gz
       - get: autounattend
       - task: create-base
         file: pipeline-resources/tasks/create-base.yml
         image: windows-stemcell-concourse-image
         input_mapping:
-          govc: govc
           autounattend: autounattend
           pipeline-resources: pipeline-resources
         params:
@@ -134,10 +122,6 @@ jobs:
     plan:
       - get: windows-stemcell-concourse-image
       - get: pipeline-resources
-      - get: govc
-        params:
-          globs:
-            - govc_linux_amd64.gz
       - get: stembuild-release
         #trigger: true #start the pipeline whenever there is a new stembuild
         params:
@@ -147,7 +131,6 @@ jobs:
         file: pipeline-resources/tasks/update-base.yml
         image: windows-stemcell-concourse-image
         input_mapping:
-          govc: govc
           pipeline-resources: pipeline-resources
         params:
           <<: *vcenter-params
@@ -160,10 +143,6 @@ jobs:
       - get: pipeline-resources
         trigger: true
         passed: [create-base]
-      - get: govc
-        params:
-          globs:
-            - govc_linux_amd64.gz
       - get: stembuild-release
         params:
           globs:
@@ -172,7 +151,6 @@ jobs:
         file: pipeline-resources/tasks/clone-base.yml
         image: windows-stemcell-concourse-image
         input_mapping:
-          govc: govc
           stembuild: stembuild-release
           pipeline-resources: pipeline-resources
         params:
@@ -186,10 +164,6 @@ jobs:
         trigger: true
         passed: [clone-base]
       - get: lgpo
-      - get: govc
-        params:
-          globs:
-            - govc_linux_amd64.gz
       - get: stembuild-release
         params:
           globs:
@@ -200,7 +174,6 @@ jobs:
         input_mapping:
           stembuild: stembuild-release
           lgpo: lgpo
-          govc: govc
           pipeline-resources: pipeline-resources
         params:
           <<: *vcenter-params
@@ -213,10 +186,6 @@ jobs:
       - get: pipeline-resources
         trigger: true
         passed: [construct]
-      - get: govc
-        params:
-          globs:
-            - govc_linux_amd64.gz
       - get: stembuild-release
         params:
           globs:
@@ -226,7 +195,6 @@ jobs:
         image: windows-stemcell-concourse-image
         input_mapping:
           stembuild: stembuild-release
-          govc: govc
           pipeline-resources: pipeline-resources
         params:
           <<: *vcenter-params

--- a/tasks/clone-base.sh
+++ b/tasks/clone-base.sh
@@ -49,18 +49,19 @@ fi
 #######################################
 #       Source helper functions
 #######################################
-# shellcheck source=./functions/utility.sh
 source "${THIS_FOLDER}/functions/utility.sh"
+source "${THIS_FOLDER}/functions/govc.sh"
 
 if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-# shellcheck source=./functions/govc.sh
-source "${THIS_FOLDER}/functions/govc.sh" \
-	-govc "${ROOT_FOLDER}/govc/govc_linux_amd64" \
-	-url "${vcenter_host}" \
-	-username "${vcenter_username}" \
-	-password "${vcenter_password}" \
-	-use-cert "${use_cert}" \
-	-cert-path "${cert_path}" || (writeErr "error initializing govc" && exit 1)
+
+if ! initializeGovc "${vcenter_host}" \
+	"${vcenter_username}" \
+	"${vcenter_password}" \
+	"${vcenter_ca_certs}" \
+	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	writeErr "error initializing govc"
+	exit 1
+fi
 
 #######################################
 #       Begin task

--- a/tasks/clone-base.sh
+++ b/tasks/clone-base.sh
@@ -52,13 +52,10 @@ fi
 source "${THIS_FOLDER}/functions/utility.sh"
 source "${THIS_FOLDER}/functions/govc.sh"
 
-if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-
 if ! initializeGovc "${vcenter_host}" \
 	"${vcenter_username}" \
 	"${vcenter_password}" \
-	"${vcenter_ca_certs}" \
-	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	"${vcenter_ca_certs}" ; then
 	writeErr "error initializing govc"
 	exit 1
 fi

--- a/tasks/clone-base.yml
+++ b/tasks/clone-base.yml
@@ -3,7 +3,6 @@ platform: linux
 
 inputs:
   - name: pipeline-resources
-  - name: govc
   - name: stembuild
 
 params:

--- a/tasks/construct.sh
+++ b/tasks/construct.sh
@@ -47,13 +47,10 @@ fi
 source "${THIS_FOLDER}/functions/utility.sh"
 source "${THIS_FOLDER}/functions/govc.sh"
 
-if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-
 if ! initializeGovc "${vcenter_host}" \
 	"${vcenter_username}" \
 	"${vcenter_password}" \
-	"${vcenter_ca_certs}" \
-	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	"${vcenter_ca_certs}" ; then
 	writeErr "error initializing govc"
 	exit 1
 fi
@@ -131,7 +128,7 @@ if ! eval ${cmd}; then
 	exit 1
 fi
 
-#Once the construct process exits, the VM is still doing work. We will know it's done with it shuts off. The following will download the govc cli and poll the VM for it's power status.
+#Once the construct process exits, the VM is still doing work. We will know it's done with it shuts off. The following will poll the VM for it's power status.
 
 echo -ne "|"
 while [[ $(getPowerState "${iPath}") == *"poweredOn"* ]]; do

--- a/tasks/construct.sh
+++ b/tasks/construct.sh
@@ -44,18 +44,19 @@ fi
 #######################################
 #       Source helper functions
 #######################################
-# shellcheck source=./functions/utility.sh
 source "${THIS_FOLDER}/functions/utility.sh"
+source "${THIS_FOLDER}/functions/govc.sh"
 
 if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-# shellcheck source=./functions/govc.sh
-source "${THIS_FOLDER}/functions/govc.sh" \
-	-govc "${ROOT_FOLDER}/govc/govc_linux_amd64" \
-	-url "${vcenter_host}" \
-	-username "${vcenter_username}" \
-	-password "${vcenter_password}" \
-	-use-cert "${use_cert}" \
-	-cert-path "${cert_path}" || (writeErr "error initializing govc" && exit 1)
+
+if ! initializeGovc "${vcenter_host}" \
+	"${vcenter_username}" \
+	"${vcenter_password}" \
+	"${vcenter_ca_certs}" \
+	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	writeErr "error initializing govc"
+	exit 1
+fi
 
 #######################################
 #       Begin task

--- a/tasks/construct.yml
+++ b/tasks/construct.yml
@@ -3,7 +3,6 @@ platform: linux
 
 inputs:
 - name: pipeline-resources
-- name: govc
 - name: stembuild
 - name: lgpo
 

--- a/tasks/create-base.sh
+++ b/tasks/create-base.sh
@@ -33,8 +33,6 @@ THIS_FOLDER="$(dirname "${BASH_SOURCE[0]}")"
 #       Default optional
 #######################################
 vcenter_ca_certs=${vcenter_ca_certs:=''}
-use_cert=${use_cert:='false'}
-cert_path=${cert_path:=''}
 vm_network=${vm_network:='VM Network'}
 vm_cpu=${vm_cpu:=4}
 vm_memory_mb=${vm_memory_mb:=8000}
@@ -51,37 +49,23 @@ firmware_type=${firmware_type:='bios'}
 disk_controller_type=${disk_controller_type:='lsilogic-sas'}
 iso_folder=${iso_folder:='Win-Stemcell-ISO'}
 
-if [[ ! -z "${vcenter_ca_certs}" ]]; then
-	use_cert="true"
-
-	#write the cert to file locally
-	(echo ${vcenter_ca_certs} | awk '
-		match($0,/- .* -/){
-			val=substr($0,RSTART,RLENGTH)
-			gsub(/- | -/,"",val)
-			gsub(OFS,ORS,val)
-			print substr($0,1,RSTART) ORS val ORS substr($0,RSTART+RLENGTH-1)}') >${ROOT_FOLDER}/cert.crt
-
-	cert_path=${ROOT_FOLDER}/cert.crt
-fi
-
 #######################################
 #       Source helper functions
 #######################################
-# shellcheck source=./functions/utility.sh
 source "${THIS_FOLDER}/functions/utility.sh"
-# shellcheck source=./functions/autounattend.sh
 source "${THIS_FOLDER}/functions/autounattend.sh"
+source "${THIS_FOLDER}/functions/govc.sh"
 
 if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-# shellcheck source=./functions/govc.sh
-source "${THIS_FOLDER}/functions/govc.sh" \
-	-govc "${ROOT_FOLDER}/govc/govc_linux_amd64" \
-	-url "${vcenter_host}" \
-	-username "${vcenter_username}" \
-	-password "${vcenter_password}" \
-	-use-cert "${use_cert}" \
-	-cert-path "${cert_path}" || (writeErr "error initializing govc" && exit 1)
+
+if ! initializeGovc "${vcenter_host}" \
+	"${vcenter_username}" \
+	"${vcenter_password}" \
+	"${vcenter_ca_certs}" \
+	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	writeErr "error initializing govc"
+	exit 1
+fi
 
 #######################################
 #       Begin task

--- a/tasks/create-base.sh
+++ b/tasks/create-base.sh
@@ -56,13 +56,10 @@ source "${THIS_FOLDER}/functions/utility.sh"
 source "${THIS_FOLDER}/functions/autounattend.sh"
 source "${THIS_FOLDER}/functions/govc.sh"
 
-if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-
 if ! initializeGovc "${vcenter_host}" \
 	"${vcenter_username}" \
 	"${vcenter_password}" \
-	"${vcenter_ca_certs}" \
-	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	"${vcenter_ca_certs}" ; then
 	writeErr "error initializing govc"
 	exit 1
 fi

--- a/tasks/create-base.yml
+++ b/tasks/create-base.yml
@@ -3,7 +3,6 @@ platform: linux
 
 inputs:
   - name: pipeline-resources
-  - name: govc
   - name: autounattend
 
 params:

--- a/tasks/functions/autounattend.sh
+++ b/tasks/functions/autounattend.sh
@@ -161,14 +161,3 @@ function buildPowershellCommand() {
 
 	return 0
 }
-
-function buildPSFileCommand() {
-	local order="${1}"
-	local description=${2}
-	local path="${3}"
-	local will_reboot="${4}"
-
-	sed -e "s|{{order}}|${order}|" -e "s|{{description}}|${description}|" -e "s|{{path}}|${path}|" -e "s|{{will_reboot}}|${will_reboot}|" ${THIS_FOLDER}/functions/sync-cmd-psfile.xml
-
-	return 0
-}

--- a/tasks/functions/govc.sh
+++ b/tasks/functions/govc.sh
@@ -2,14 +2,7 @@
 
 #
 # Task Description:
-#   Functions to run dotnet actions. By adding this script as a source, the required binaries
-#   will automatically be installed
-#
-#	The targeted dotnet version can be overwritten by exporting DOTNET_VERSION
-#	ie: export DOTNET_VERSION=2.x.x
-#
-
-exec 5>&1
+#   Functions to interact with govc cli
 
 ######################################
 # Description:

--- a/tasks/functions/govc.sh
+++ b/tasks/functions/govc.sh
@@ -32,7 +32,7 @@ function initializeGovc() {
 
 	echo "Initializing govc"
 
-	export GOVC_EXE="${govc_file_path}"
+	export GOVC_EXE="govc"
 	export GOVC_URL="${vcenter_host}"
 	export GOVC_USERNAME="${vcenter_username}"
 	export GOVC_PASSWORD="${vcenter_password}"

--- a/tasks/functions/govc.sh
+++ b/tasks/functions/govc.sh
@@ -80,13 +80,13 @@ function powershellCmd() {
 	local vm_password="${3}"
 	local script="${4}"
 
-	if ! pid=$(${GOVC_EXE} guest.start -ipath=${vm_ipath} -l=${vm_username}:${vm_password} \
+	if ! pid=$(${GOVC_EXE} guest.start -vm.ipath=${vm_ipath} -l=${vm_username}:${vm_password} \
 		'C:\\Windows\\System32\\WindowsPowerShell\\V1.0\\powershell.exe -NoProfile -Command "'+${script}+'"'); then
 		writeErr "could not run powershell command on VM at ${vm_ipath}"
 		return 1
 	fi
 
-	if ! processInfo=$(${GOVC_EXE} guest.ps -ipath=${vm_ipath} -l=${vm_username}:${vm_password} -p=${pid} -X=true -x -json); then
+	if ! processInfo=$(${GOVC_EXE} guest.ps -vm.ipath=${vm_ipath} -l=${vm_username}:${vm_password} -p=${pid} -X=true -x -json); then
 		writeErr "could not get powershell process info on VM at ${vm_ipath}"
 		return 1
 	fi
@@ -97,27 +97,6 @@ function powershellCmd() {
 	fi
 
 	echo "${exitCode}"
-	return 0
-}
-
-######################################
-# Description:
-#
-# Arguments:
-#
-#######################################
-function uploadFile() {
-	local vm_ipath="${1}"
-	local vm_username="${2}"
-	local vm_password="${3}"
-	local source_file="${4}"
-	local dest_file="${5}"
-
-	if ! ${GOVC_EXE} guest.upload -ipath=${vm_ipath} -l=${vm_username}:${vm_password} -f=true "${source_file}" "${dest_file}"; then
-		writeErr "Could not upload file to VM at ${vm_ipath}"
-		return 1
-	fi
-
 	return 0
 }
 
@@ -162,7 +141,7 @@ function mkdir() {
 	local vm_password="${3}"
 	local folder_Path="${4}"
 
-	if ! ${GOVC_EXE} guest.mkdir -ipath=${vm_ipath} -l=${vm_username}:${vm_password} "${folder_Path}"; then
+	if ! ${GOVC_EXE} guest.mkdir -vm.ipath=${vm_ipath} -l=${vm_username}:${vm_password} "${folder_Path}"; then
 		writeErr "Could not make dir on VM at ${vm_ipath}"
 		return 1
 	fi

--- a/tasks/functions/govc.sh
+++ b/tasks/functions/govc.sh
@@ -80,8 +80,10 @@ function powershellCmd() {
 	local vm_password="${3}"
 	local script="${4}"
 
-	if ! pid=$(${GOVC_EXE} guest.start -vm.ipath=${vm_ipath} -l=${vm_username}:${vm_password} \
-		'C:\\Windows\\System32\\WindowsPowerShell\\V1.0\\powershell.exe -NoProfile -Command "'+${script}+'"'); then
+	echo "Running PS: ${script}"
+
+	local cmd=(C:\\Windows\\System32\\WindowsPowerShell\\V1.0\\powershell.exe -NoProfile -Command "${script}")
+	if ! pid=$(${GOVC_EXE} guest.start -vm.ipath="${vm_ipath}" -l="${vm_username}:${vm_password}" "${cmd[@]}"); then
 		writeErr "could not run powershell command on VM at ${vm_ipath}"
 		return 1
 	fi
@@ -91,12 +93,12 @@ function powershellCmd() {
 		return 1
 	fi
 
-	if ! exitCode=$(echo "${processInfo}" | jq '.info.ProcessInfo[0].ExitCode'); then
+	if ! exitCode=$(echo "${processInfo}" | jq '.ProcessInfo[0].ExitCode'); then
 		writeErr "process info not be parsed for powershell command on VM at ${vm_ipath}"
 		return 1
 	fi
 
-	echo "${exitCode}"
+	echo "Exit code: ${exitCode}"
 	return 0
 }
 

--- a/tasks/functions/govc.sh
+++ b/tasks/functions/govc.sh
@@ -41,14 +41,7 @@ function initializeGovc() {
 		GOVC_TLS_CA_CERTS=$(mktemp)
 		export GOVC_TLS_CA_CERTS
 		export GOVC_INSECURE=0
-
-		# write the cert to file locally
-		(echo "${vcenter_ca_certs}" | awk '
-			match($0,/- .* -/){
-				val=substr($0,RSTART,RLENGTH)
-				gsub(/- | -/,"",val)
-				gsub(OFS,ORS,val)
-				print substr($0,1,RSTART) ORS val ORS substr($0,RSTART+RLENGTH-1)}') > "${GOVC_TLS_CA_CERTS}"
+		cat <<< "${vcenter_ca_certs}" > "${GOVC_TLS_CA_CERTS}"
 	else
 		export GOVC_INSECURE=1
 	fi

--- a/tasks/functions/utility.sh
+++ b/tasks/functions/utility.sh
@@ -37,39 +37,6 @@ subnetMaskToCidr() {
 # Arguments:
 #		None
 #######################################
-function findFileExpandArchive() {
-	local filePath="${1}"
-	local archivePath="${2}"
-	local asExecutable="${3}"
-
-	file=$(find "${filePath}" 2>/dev/null | head -n1)
-	if [[ -z ${file} ]]; then
-		archive=$(find "${archivePath}" 2>/dev/null | head -n1)
-		if [[ -z ${archive} ]]; then
-			writeErr "no archive found at path ${archivePath}"
-			return 1
-		else
-			gunzip "${archivePath}"
-		fi
-
-		file2=$(find "${filePath}" 2>/dev/null | head -n1)
-		if [[ -z ${file2} ]]; then
-			writeErr "could not find file '${filePath}' after expanding archive at '${archivePath}'"
-			return 1
-		fi
-	fi
-
-	[[ ${asExecutable} == true ]] && chmod +x ${filePath}
-
-	return 0
-}
-
-######################################
-# Description:
-#
-# Arguments:
-#		None
-#######################################
 function parseStembuildVersion() {
 	local stembuildVersionOutput="${1}"
 	#stembuild-linux-x86_64-2019.12 version 2019.12.26, Windows Stemcell Building Tool

--- a/tasks/package.sh
+++ b/tasks/package.sh
@@ -45,18 +45,19 @@ fi
 #######################################
 #       Source helper functions
 #######################################
-# shellcheck source=./functions/utility.sh
 source "${THIS_FOLDER}/functions/utility.sh"
+source "${THIS_FOLDER}/functions/govc.sh"
 
 if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-# shellcheck source=./functions/govc.sh
-source "${THIS_FOLDER}/functions/govc.sh" \
-	-govc "${ROOT_FOLDER}/govc/govc_linux_amd64" \
-	-url "${vcenter_host}" \
-	-username "${vcenter_username}" \
-	-password "${vcenter_password}" \
-	-use-cert "${use_cert}" \
-	-cert-path "${cert_path}" || (writeErr "error initializing govc" && exit 1)
+
+if ! initializeGovc "${vcenter_host}" \
+	"${vcenter_username}" \
+	"${vcenter_password}" \
+	"${vcenter_ca_certs}" \
+	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	writeErr "error initializing govc"
+	exit 1
+fi
 
 #######################################
 #       Begin task

--- a/tasks/package.sh
+++ b/tasks/package.sh
@@ -48,13 +48,10 @@ fi
 source "${THIS_FOLDER}/functions/utility.sh"
 source "${THIS_FOLDER}/functions/govc.sh"
 
-if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-
 if ! initializeGovc "${vcenter_host}" \
 	"${vcenter_username}" \
 	"${vcenter_password}" \
-	"${vcenter_ca_certs}" \
-	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	"${vcenter_ca_certs}" ; then
 	writeErr "error initializing govc"
 	exit 1
 fi

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -3,7 +3,6 @@ platform: linux
 
 inputs:
 - name: pipeline-resources
-- name: govc
 - name: stembuild
 
 params:

--- a/tasks/update-base.sh
+++ b/tasks/update-base.sh
@@ -44,18 +44,19 @@ fi
 #######################################
 #       Source helper functions
 #######################################
-# shellcheck source=./functions/utility.sh
 source "${THIS_FOLDER}/functions/utility.sh"
+source "${THIS_FOLDER}/functions/govc.sh"
 
 if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-# shellcheck source=./functions/govc.sh
-source "${THIS_FOLDER}/functions/govc.sh" \
-	-govc "${ROOT_FOLDER}/govc/govc_linux_amd64" \
-	-url "${vcenter_host}" \
-	-username "${vcenter_username}" \
-	-password "${vcenter_password}" \
-	-use-cert "${use_cert}" \
-	-cert-path "${cert_path}" || (writeErr "error initializing govc" && exit 1)
+
+if ! initializeGovc "${vcenter_host}" \
+	"${vcenter_username}" \
+	"${vcenter_password}" \
+	"${vcenter_ca_certs}" \
+	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	writeErr "error initializing govc"
+	exit 1
+fi
 
 #######################################
 #       Begin task

--- a/tasks/update-base.sh
+++ b/tasks/update-base.sh
@@ -47,13 +47,10 @@ fi
 source "${THIS_FOLDER}/functions/utility.sh"
 source "${THIS_FOLDER}/functions/govc.sh"
 
-if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-
 if ! initializeGovc "${vcenter_host}" \
 	"${vcenter_username}" \
 	"${vcenter_password}" \
-	"${vcenter_ca_certs}" \
-	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	"${vcenter_ca_certs}" ; then
 	writeErr "error initializing govc"
 	exit 1
 fi

--- a/tasks/update-base.yml
+++ b/tasks/update-base.yml
@@ -3,7 +3,6 @@ platform: linux
 
 inputs:
 - name: pipeline-resources
-- name: govc
 
 params:
   vcenter_host: ((vcenter-host))

--- a/tests/concourse.sh
+++ b/tests/concourse.sh
@@ -11,7 +11,6 @@ cp "${ROOT_FOLDER}/assets/autounattend.xml" "${THIS_FOLDER}/autounattend/autouna
 fly -t con execute \
   -c ${ROOT_FOLDER}/tasks/create-base.yml \
   -i pipeline-resources=${ROOT_FOLDER} \
-  -i govc=${THIS_FOLDER}/govc \
   -i autounattend=${THIS_FOLDER}/autounattend \
   -i iso=${THIS_FOLDER}/iso \
   -l ${ROOT_FOLDER}/vars/my-vars.yml \
@@ -22,7 +21,6 @@ date -u
 fly -t con execute \
   -c ${ROOT_FOLDER}/tasks/clone-base.yml \
   -i pipeline-resources=${ROOT_FOLDER} \
-  -i govc=${THIS_FOLDER}/govc \
   -i stembuild=${THIS_FOLDER}/stembuild \
   -l ${ROOT_FOLDER}/vars/my-vars.yml \
   --privileged
@@ -32,7 +30,6 @@ date -u
 fly -t con execute \
   -c ${ROOT_FOLDER}/tasks/construct.yml \
   -i pipeline-resources=${ROOT_FOLDER} \
-  -i govc=${THIS_FOLDER}/govc \
   -i stembuild=${THIS_FOLDER}/stembuild \
   -i lgpo=${THIS_FOLDER}/lgpo \
   -l ${ROOT_FOLDER}/vars/my-vars.yml \
@@ -43,7 +40,6 @@ date -u
 fly -t con execute \
   -c ${ROOT_FOLDER}/tasks/package.yml \
   -i pipeline-resources=${ROOT_FOLDER} \
-  -i govc=${THIS_FOLDER}/govc \
   -i stembuild=${THIS_FOLDER}/stembuild \
   -l ${ROOT_FOLDER}/vars/my-vars.yml \
   --output stemcell=${THIS_FOLDER}/stemcell \
@@ -54,7 +50,6 @@ date -u
 fly -t con execute \
   -c ${ROOT_FOLDER}/tasks/update-base.yml \
   -i pipeline-resources=${ROOT_FOLDER} \
-  -i govc=${THIS_FOLDER}/govc \
   -l ${ROOT_FOLDER}/vars/my-vars.yml \
   --privileged
 

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -299,18 +299,20 @@ function testPackage() {
 #===============================================================================
 # SOURCE SCRIPTS
 #===============================================================================
-# shellcheck source=../tasks/functions/utility.sh
 source "${THIS_FOLDER}/functions/utility.sh"
-# shellcheck source=../tasks/functions/autounattend.sh
 source "${THIS_FOLDER}/functions/autounattend.sh"
-# shellcheck source=../tasks/functions/govc.sh
-source "${THIS_FOLDER}/functions/govc.sh" \
-	-govc "sudo -E $(find ${ROOT_FOLDER}/govc/govc_linux_* 2>/dev/null | head -n1)" \
-	-url "${vcenter_host}" \
-	-username "${vcenter_username}" \
-	-password "${vcenter_password}" \
-	-use-cert "${use_cert}" \
-	-cert-path "${cert_path}"
+source "${THIS_FOLDER}/functions/govc.sh"
+
+if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
+
+if ! initializeGovc "${vcenter_host}" \
+	"${vcenter_username}" \
+	"${vcenter_password}" \
+	"${vcenter_ca_certs}" \
+	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	writeErr "error initializing govc"
+	exit 1
+fi
 
 #===============================================================================
 # VARIABLES

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -303,13 +303,10 @@ source "${THIS_FOLDER}/functions/utility.sh"
 source "${THIS_FOLDER}/functions/autounattend.sh"
 source "${THIS_FOLDER}/functions/govc.sh"
 
-if ! findFileExpandArchive "${ROOT_FOLDER}/govc/govc_linux_amd64" "${ROOT_FOLDER}/govc/govc_linux_amd64.gz" true; then exit 1; fi
-
 if ! initializeGovc "${vcenter_host}" \
 	"${vcenter_username}" \
 	"${vcenter_password}" \
-	"${vcenter_ca_certs}" \
-	"${ROOT_FOLDER}/govc/govc_linux_amd64" ; then
+	"${vcenter_ca_certs}" ; then
 	writeErr "error initializing govc"
 	exit 1
 fi


### PR DESCRIPTION
This removes the need to download govc from github as part of every build and bake it into the container the build uses. This simplifies the build pipeline and makes offline scenarios simpler.

Govc initialization is now explicit so that the govc.sh file could be sourced without side effects. This will make is easier to test functions in the future.

- vSphere certs are written directly to a temp file and used from there by govc
- Fixed args in the update base vm functions