### PR TITLE
Update clone-base.yml

### DIFF
--- a/tasks/clone-base.yml
+++ b/tasks/clone-base.yml
@@ -24,8 +24,5 @@ params:
   vmware_tools_status: ((vmware-tools-status))
   timeout: ((timeout))
 
-  vmware_tools_status: ((vmware-tools-status))
-  timeout: ((timeout))
-
 run:
   path: pipeline-resources/tasks/clone-base.sh


### PR DESCRIPTION
removed duplicate keys for vmware_tools_status and timeout

updates issue https://github.com/cloudfoundry-community/windows-stemcell-concourse/issues/47