### PR TITLE
Update construct.yml

### DIFF
--- a/tasks/construct.yml
+++ b/tasks/construct.yml
@@ -20,8 +20,5 @@ params:
   vmware_tools_status: ((vmware-tools-status))
   timeout: ((timeout))
 
-  vmware_tools_status: ((vmware-tools-status))
-  timeout: ((timeout))
-
 run:
   path: pipeline-resources/tasks/construct.sh


### PR DESCRIPTION
Removed duplicate vmware_tools_statis and timeout keys.

Fixes
https://github.com/cloudfoundry-community/windows-stemcell-concourse/issues/49
